### PR TITLE
fix: check initial scroll position on header mount

### DIFF
--- a/src/tsx/layout/Header.tsx
+++ b/src/tsx/layout/Header.tsx
@@ -44,6 +44,7 @@ function Header() {
       }
     }
 
+    handleScroll()
     window.addEventListener('scroll', handleScroll)
 
     return () => window.removeEventListener('scroll', handleScroll)


### PR DESCRIPTION
## Summary
- Fixes header background not showing when page is reloaded while scrolled
- Calls `handleScroll()` on mount to check initial scroll position

close #219

## Test plan
- [x] Scroll down on the page
- [x] Reload the page while scrolled
- [x] Verify header has white background immediately