### PR TITLE
style(footer): redesign credits section for cleaner appearance

### DIFF
--- a/src/tsx/layout/Footer.tsx
+++ b/src/tsx/layout/Footer.tsx
@@ -59,9 +59,13 @@ function Footer() {
               </li>
             </ul>
           </nav>
-          <p className="text-sm text-center mt-3 sm:text-left md:text-right">
-            Made with ✨ by PROGEEK GmbH & Hochschule Flensburg <br />
-            {import.meta.env.VITE_APP_VERSION} • Build {import.meta.env.VITE_BUILD_VERSION}
+          <p className="text-xs text-center mt-3 text-white/60 sm:text-left md:text-right">
+            © {new Date().getFullYear()} PROGEEK GmbH & Hochschule Flensburg
+            <span className="hidden sm:inline"> · </span>
+            <br className="sm:hidden" />
+            <span className="text-white/40">
+              {import.meta.env.VITE_APP_VERSION} · {import.meta.env.VITE_BUILD_VERSION}
+            </span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Smaller font size (`text-xs`) and muted colors (`white/60`, `white/40`)
- Replace "Made with ✨ by" with copyright symbol (©)
- Dynamic year using `Date().getFullYear()`
- Responsive: single line on desktop, two lines on mobile

## Test plan
- [x] Check footer on desktop (single line)
- [x] Check footer on mobile (two lines)
- [x] Verify year displays correctly