### PR TITLE
fix(security): add rel noopener noreferrer to external links

### DIFF
--- a/src/tsx/components/Button.tsx
+++ b/src/tsx/components/Button.tsx
@@ -20,7 +20,13 @@ const Button: React.FC<ButtonProps> = ({
 
   if (isExternalLink) {
     return (
-      <a href={href} aria-label={ariaLabel} target="_blank" className={className}>
+      <a
+        href={href}
+        aria-label={ariaLabel}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
         {children}
       </a>
     )

--- a/src/tsx/components/cards/StakeholderCard.tsx
+++ b/src/tsx/components/cards/StakeholderCard.tsx
@@ -36,6 +36,7 @@ const StakeholderCard: React.FC<StakeholderCardProps> = ({
         <a
           href={url}
           target="_blank"
+          rel="noopener noreferrer"
           className="text-green-dark-900 font-bold flex itemx-center gap-x-4 group"
         >
           <p className="transition-all ease-in-out duration-300 group-hover:text-green-light-900">

--- a/src/tsx/components/navigation/NavItem.tsx
+++ b/src/tsx/components/navigation/NavItem.tsx
@@ -24,7 +24,7 @@ const NavItem: React.FC<NavItemProps> = ({ label, url, isExternalLink = false, o
   return (
     <li className="mb-4 lg:mb-0">
       {isExternalLink ? (
-        <a href={url} target="_blank" className={className}>
+        <a href={url} target="_blank" rel="noopener noreferrer" className={className}>
           {content}
         </a>
       ) : (


### PR DESCRIPTION
## Summary
- Adds `rel="noopener noreferrer"` to all external links with `target="_blank"`
- Prevents reverse tabnabbing security vulnerability
- Improves accessibility compliance

## Changed Files
- `src/tsx/components/Button.tsx`
- `src/tsx/components/cards/StakeholderCard.tsx`
- `src/tsx/components/navigation/NavItem.tsx`

Note: `MainNavigation.tsx` already had the correct `rel` attribute.

## Test Plan
- [x] Verify external links open in new tab
- [x] Check that `rel="noopener noreferrer"` is present in rendered HTML

Closes #230