### PR TITLE
feat(ux): add loading state for video thumbnails

### DIFF
--- a/src/tsx/components/VideoPreview.tsx
+++ b/src/tsx/components/VideoPreview.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+interface VideoPreviewProps {
+  thumbnail: string
+}
+
+function VideoPreview({ thumbnail }: VideoPreviewProps) {
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  return (
+    <div className="relative w-full h-full">
+      {!isLoaded && (
+        <div className="absolute inset-0 bg-gradient-to-r from-grey-100 via-white to-grey-100 bg-[length:200%_100%] animate-shimmer rounded-lg" />
+      )}
+      <img
+        src={thumbnail}
+        alt=""
+        className={`w-full h-full object-cover transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}
+        onLoad={() => setIsLoaded(true)}
+      />
+    </div>
+  )
+}
+
+export default VideoPreview

--- a/src/tsx/components/sections/Videos.tsx
+++ b/src/tsx/components/sections/Videos.tsx
@@ -1,4 +1,5 @@
 import ReactPlayer from 'react-player'
+import VideoPreview from '../VideoPreview'
 
 const VIDEO_SHORT =
   'https://s3.green-ecolution.de/public-videos/project-video/short/green-ecolution-short.m3u8'
@@ -25,7 +26,7 @@ const VideoCard = (props: {
         width="100%"
         height="auto"
         style={{ width: '100%', height: 'auto', aspectRatio: '16/9' }}
-        light={props.thumbnail}
+        light={<VideoPreview thumbnail={props.thumbnail} />}
       />
     </div>
     <h3 className="mt-8 mb-4 font-lato text-xl lg:text-2xl">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,9 +74,14 @@ export default {
           '0%, 100%': { transform: 'translate(0,0)' },
           '50%': { transform: 'translate(50%,0)' },
         },
+        shimmer: {
+          '0%': { backgroundPosition: '200% 0' },
+          '100%': { backgroundPosition: '-200% 0' },
+        },
       },
       animation: {
         move: 'move 35s linear infinite',
+        shimmer: 'shimmer 1.5s ease-in-out infinite',
       },
       transitionDelay: {
         1500: '1500ms',


### PR DESCRIPTION
## Summary
- Add shimmer animation skeleton while video thumbnails load
- Create `VideoPreview` component with loading state
- Use ReactPlayer's `light` prop with custom React element

## Changes
- `src/tsx/components/VideoPreview.tsx` - New component with skeleton loading
- `src/tsx/components/sections/Videos.tsx` - Use VideoPreview as light prop
- `tailwind.config.js` - Add shimmer keyframe animation

## Test plan
- [x] Load page with videos section
- [x] Observe shimmer skeleton before thumbnail appears
- [x] Click play to verify video still works

Closes #234