### PR TITLE
fix(ux): add active states for touch device feedback

### DIFF
--- a/src/tsx/components/Button.tsx
+++ b/src/tsx/components/Button.tsx
@@ -16,7 +16,7 @@ const Button: React.FC<ButtonProps> = ({
   isExternalLink = false,
   isDark = false,
 }) => {
-  const className = `flex items-center justify-center gap-x-4 rounded-2xl w-max font-semibold px-5 py-2 group transition-color ease-in-out duration-300 text-white hover:bg-green-light-900 hover:border-green-light-900 ${isDark ? 'bg-green-dark-900' : 'bg-transparent border border-white'}`
+  const className = `flex items-center justify-center gap-x-4 rounded-2xl w-max font-semibold px-5 py-2 group transition-color ease-in-out duration-300 text-white hover:bg-green-light-900 hover:border-green-light-900 active:bg-green-light-900 active:border-green-light-900 ${isDark ? 'bg-green-dark-900' : 'bg-transparent border border-white'}`
 
   if (isExternalLink) {
     return (

--- a/src/tsx/components/cards/StakeholderCard.tsx
+++ b/src/tsx/components/cards/StakeholderCard.tsx
@@ -39,10 +39,10 @@ const StakeholderCard: React.FC<StakeholderCardProps> = ({
           rel="noopener noreferrer"
           className="text-green-dark-900 font-bold flex itemx-center gap-x-4 group"
         >
-          <p className="transition-all ease-in-out duration-300 group-hover:text-green-light-900">
+          <p className="transition-all ease-in-out duration-300 group-hover:text-green-light-900 group-active:text-green-light-900">
             Zur Webseite
           </p>
-          <Arrow classes="w-6 transition-all ease-in-out duration-300 group-hover:translate-x-2 group-hover:text-green-light-900" />
+          <Arrow classes="w-6 transition-all ease-in-out duration-300 group-hover:translate-x-2 group-hover:text-green-light-900 group-active:translate-x-2 group-active:text-green-light-900" />
         </a>
       </figcaption>
     </figure>

--- a/src/tsx/components/navigation/NavItem.tsx
+++ b/src/tsx/components/navigation/NavItem.tsx
@@ -14,10 +14,10 @@ const NavItem: React.FC<NavItemProps> = ({ label, url, isExternalLink = false, o
 
   const content = (
     <>
-      <p className="transition-color ease-in-out duration-300 group-hover:text-green-light-900 lg:group-hover:text-green-middle-900">
+      <p className="transition-color ease-in-out duration-300 group-hover:text-green-light-900 group-active:text-green-light-900 lg:group-hover:text-green-middle-900 lg:group-active:text-green-middle-900">
         {label}
       </p>
-      <Arrow classes="w-6 transition-all ease-in-out duration-300 group-hover:translate-x-2 group-hover:text-green-light-900 lg:hidden" />
+      <Arrow classes="w-6 transition-all ease-in-out duration-300 group-hover:translate-x-2 group-hover:text-green-light-900 group-active:translate-x-2 group-active:text-green-light-900 lg:hidden" />
     </>
   )
 

--- a/src/tsx/components/sections/FurhterLinks.tsx
+++ b/src/tsx/components/sections/FurhterLinks.tsx
@@ -54,13 +54,13 @@ function FurtherLinks() {
             <a
               href={link.url}
               target="_blank"
-              className="px-4 py-3 group rounded-2xl cursor-pointer flex items-center justify-between gap-x-8 transition-color ease-in-out duration-300 md:px-6 md:py-4 hover:bg-green-dark-900/10"
+              className="px-4 py-3 group rounded-2xl cursor-pointer flex items-center justify-between gap-x-8 transition-color ease-in-out duration-300 md:px-6 md:py-4 hover:bg-green-dark-900/10 active:bg-green-dark-900/20"
             >
               <div>
                 <h3 className="font-lato font-semibold text-lg mb-2">{link.label}</h3>
                 <p className="text-base">{link.subLabel}</p>
               </div>
-              <figure className="shrink-0 transition-all ease-in-out duration-300 group-hover:translate-x-1">
+              <figure className="shrink-0 transition-all ease-in-out duration-300 group-hover:translate-x-1 group-active:translate-x-1">
                 <img
                   src="/assets/svg/general/arrow.svg"
                   className="object-contain w-6 h-6 "


### PR DESCRIPTION
## Summary
Add `active:` states alongside `hover:` states to provide visual feedback on touch devices when tapping interactive elements.

## Changes
- `src/tsx/components/sections/FurhterLinks.tsx` - Add `active:bg-green-dark-900/20` and `group-active:translate-x-1`
- `src/tsx/components/navigation/NavItem.tsx` - Add `group-active:` for text color and arrow translation
- `src/tsx/components/cards/StakeholderCard.tsx` - Add `group-active:` for link hover effects
- `src/tsx/components/Button.tsx` - Add `active:bg-green-light-900 active:border-green-light-900`

## Test plan
- [x] Test on touch device (or use Chrome DevTools touch simulation)
- [x] Tap interactive elements and verify visual feedback appears
- [x] Verify hover states still work on desktop

Closes #235