### PR TITLE
fix(seo): add static og:image for social crawlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       property="og:description"
       content="Die Projektwebsite zum Projekt »Green Ecolution« für smartes Grünflächenmanagement."
     />
-    <meta property="og:image" content="" id="og-image" />
+    <meta property="og:image" content="/assets/images/open-graph-image.png" />
   </head>
   <body
     class="bg-white antialiased font-nunito-sans text-base text-grey-900 w-full overflow-x-hidden lg:text-lg selection:bg-green-light-900/20 selection:text-grey-900"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,12 +19,6 @@ declare module '@tanstack/react-router' {
   }
 }
 
-const ogImage = document.getElementById('og-image')
-if (ogImage) {
-  const currentDomain = window.location.origin
-  ogImage.setAttribute('content', currentDomain + '/assets/images/open-graph-image.png')
-}
-
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <RouterProvider router={router} />


### PR DESCRIPTION
## Summary
Social media crawlers (Facebook, Twitter, LinkedIn) don't execute JavaScript, so the dynamically set `og:image` was empty. This fix adds a static relative path directly in index.html.

## Changes
- `index.html` - Set static `og:image` content: `/assets/images/open-graph-image.png`
- `src/main.tsx` - Remove JavaScript code that dynamically set the og:image

## Test plan
- [ ] Use [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) to verify og:image is detected
- [ ] Use [Twitter Card Validator](https://cards-dev.twitter.com/validator) to verify image appears
- [ ] Check that the image displays when sharing on social media

Closes #237