### PR TITLE
feat(seo): add Schema.org JSON-LD structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,16 @@
       content="Die Projektwebsite zum Projekt »Green Ecolution« für smartes Grünflächenmanagement."
     />
     <meta property="og:image" content="/assets/images/open-graph-image.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Green Ecolution",
+        "url": "https://green-ecolution.de",
+        "logo": "https://green-ecolution.de/assets/favicons/favicon.svg",
+        "description": "Smartes Grünflächenmanagement für nachhaltige Stadtentwicklung"
+      }
+    </script>
   </head>
   <body
     class="bg-white antialiased font-nunito-sans text-base text-grey-900 w-full overflow-x-hidden lg:text-lg selection:bg-green-light-900/20 selection:text-grey-900"

--- a/src/tsx/components/BreadcrumbSchema.tsx
+++ b/src/tsx/components/BreadcrumbSchema.tsx
@@ -1,0 +1,33 @@
+interface BreadcrumbItem {
+  name: string
+  path: string
+}
+
+interface BreadcrumbSchemaProps {
+  items: BreadcrumbItem[]
+}
+
+const BASE_URL = 'https://green-ecolution.de'
+
+function BreadcrumbSchema({ items }: BreadcrumbSchemaProps) {
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: `${BASE_URL}${item.path}`,
+    })),
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react-dom/no-dangerously-set-innerhtml
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}
+
+export default BreadcrumbSchema

--- a/src/tsx/components/sections/Faq.tsx
+++ b/src/tsx/components/sections/Faq.tsx
@@ -1,8 +1,54 @@
 import Accordion from '../Accordion'
 
+const faqData = [
+  {
+    question: 'Wer steckt hinter dem Projekt Green Ecolution?',
+    answer:
+      'Das Projekt "Green Ecolution" wurde im Rahmen eines Forschungsprojekts im Masterstudiengang "Angewandte Informatik" an der Hochschule Flensburg ins Leben gerufen. Nach dem erfolgreichen Abschluss des Forschungsprojekts wird die Weiterentwicklung des Systems nun von PROGEEK übernommen, in enger Zusammenarbeit mit der Smarten Grenzregion und der Stadt Flensburg.',
+  },
+  {
+    question: 'Welchen Mehrwert bietet das Projekt?',
+    answer:
+      'Das Forschungsprojekt "Green Ecolution" hat gezeigt, wie digitale Technologien gezielt eingesetzt werden können, um die Bewässerung von Stadtbäumen effizienter, nachhaltiger und ressourcenschonender zu gestalten. Durch den Einsatz moderner Sensorik und intelligenter Datenauswertung wurde eine Grundlage geschaffen, um Wasserverbrauch und Pflegeaufwand deutlich zu reduzieren.',
+  },
+  {
+    question: 'Was bedeutet es, dass das Projekt öffentlich zugänglich ist?',
+    answer:
+      'Der Quellcode des Projekts ist in einem öffentlich zugänglichen GitHub-Repository verfügbar. Dadurch kann der aktuelle Entwicklungsstand jederzeit eingesehen werden, was Transparenz schafft und interessierten Personen ermöglicht, die Weiterentwicklung nachzuvollziehen oder sich aktiv einzubringen.',
+  },
+  {
+    question: 'Welche Sensoren werden eingesetzt?',
+    answer:
+      'Im Rahmen des Forschungsprojekts wurden Watermark-Sensoren zur Messung der Bodenwasserspannung und SMT100-Sensoren zur Messung der Bodenfeuchte und -temperatur eingesetzt. Diese Sensoren bildeten die Grundlage für die Entwicklung und Erprobung des Systems.',
+  },
+  {
+    question: 'Wie ist der aktuelle Fortschritt des Projekts?',
+    answer:
+      'Das Forschungsprojekt „Green Ecolution" wurde im Rahmen des Masterstudiengangs „Angewandte Informatik" an der Hochschule Flensburg erfolgreich abgeschlossen. Im Oktober 2025 erhielt das Projekt im Rahmen des DigitalHub Call for Concepts eine Förderung. Aktuell arbeiten PROGEEK, die Stadt Flensburg und die Smarte Grenzregion gemeinsam an der Weiterentwicklung.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqData.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answer,
+    },
+  })),
+}
+
 function Faq() {
   return (
     <section className="px-4 max-w-208 mx-auto my-28 md:px-6 lg:my-36 xl:my-52">
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react-dom/no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
       <h2 className="font-lato font-bold text-center text-2xl mb-6 lg:mb-10 lg:text-3xl">
         Oft gestellte Fragen zu Green Ecolution
       </h2>

--- a/src/tsx/pages/ContactPage.tsx
+++ b/src/tsx/pages/ContactPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import ContactHeroContent from '../components/hero/ContactHeroContent'
 import Hero from '../components/sections/Hero'
 import Stakeholder from '../components/sections/Stakeholder'
+import BreadcrumbSchema from '../components/BreadcrumbSchema'
 
 function ContactPage() {
   useEffect(() => {
@@ -17,6 +18,12 @@ function ContactPage() {
       id="main-content"
       className="relative overflow-hidden before:bg-cover before:bg-background-dark-dot before:w-4/5 before:h-[100vh] before:max-h-[45rem] before:absolute before:-right-4 before:-top-16 before:-z-10 before:bg-no-repeat sm:before:-right-10 lg:before:max-h-[55rem] xl:before:w-[70rem] xl:before:-right-40 2xl:before:right-[10%] 2xl:before:bg-contain"
     >
+      <BreadcrumbSchema
+        items={[
+          { name: 'Startseite', path: '/' },
+          { name: 'Kontakt', path: '/contact' },
+        ]}
+      />
       <Hero headline={heroHeadline} description={heroDescription}>
         <ContactHeroContent />
       </Hero>

--- a/src/tsx/pages/HomePage.tsx
+++ b/src/tsx/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import Process from './../components/sections/Process'
 import Stakeholder from './../components/sections/Stakeholder'
 import Videos from '../components/sections/Videos'
 import LatestRelease from '../components/sections/LatestRelease'
+import BreadcrumbSchema from '../components/BreadcrumbSchema'
 
 function HomePage() {
   useEffect(() => {
@@ -16,6 +17,7 @@ function HomePage() {
 
   return (
     <main id="main-content">
+      <BreadcrumbSchema items={[{ name: 'Startseite', path: '/' }]} />
       <HompageHero />
       <HomepageDevider />
       <Introduction />

--- a/src/tsx/pages/ProjectPage.tsx
+++ b/src/tsx/pages/ProjectPage.tsx
@@ -5,6 +5,7 @@ import Hero from '../components/sections/Hero'
 import Contact from '../components/sections/Contact'
 import ProjectHeroContent from '../components/hero/ProjectHeroContent'
 import FurtherLinks from '../components/sections/FurhterLinks'
+import BreadcrumbSchema from '../components/BreadcrumbSchema'
 
 function ProjectPage() {
   useEffect(() => {
@@ -34,6 +35,12 @@ function ProjectPage() {
       id="main-content"
       className="relative overflow-hidden before:bg-cover before:bg-background-light-dot before:w-4/5 before:h-[100vh] before:max-h-[45rem] before:absolute before:-right-4 before:-top-16 before:-z-10 before:bg-no-repeat sm:before:-right-10 lg:before:max-h-[55rem] xl:before:w-[70rem] xl:before:-right-40 2xl:before:right-[10%] 2xl:before:bg-contain"
     >
+      <BreadcrumbSchema
+        items={[
+          { name: 'Startseite', path: '/' },
+          { name: 'Projekt', path: '/project' },
+        ]}
+      />
       <Hero headline={heroHeadline} description={heroDescription}>
         <ProjectHeroContent />
       </Hero>


### PR DESCRIPTION
## Summary
Add Schema.org structured data (JSON-LD) for improved SEO and rich search results.

## Changes

### Organization Schema (index.html)
Static JSON-LD with organization info (name, url, logo, description).

### FAQPage Schema (Faq.tsx)
Dynamic JSON-LD generated from FAQ data array. Enables FAQ rich snippets in search results.

### BreadcrumbList Schema (new component)
- `src/tsx/components/BreadcrumbSchema.tsx` - Reusable component
- Added to HomePage, ProjectPage, ContactPage with appropriate breadcrumb trails

## Files Changed
- `index.html` - Organization schema
- `src/tsx/components/BreadcrumbSchema.tsx` - New component
- `src/tsx/components/sections/Faq.tsx` - FAQPage schema + data array
- `src/tsx/pages/HomePage.tsx` - BreadcrumbSchema
- `src/tsx/pages/ProjectPage.tsx` - BreadcrumbSchema
- `src/tsx/pages/ContactPage.tsx` - BreadcrumbSchema

## Test plan
- [x] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [x] Validate with [Schema.org Validator](https://validator.schema.org/)
- [x] Check all three schema types appear in page source

Closes #238