### PR TITLE
perf: add vendor splitting for better caching

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,5 +25,17 @@ export default defineConfig(() => {
 
   return {
     plugins: [TanStackRouterVite({ routesDirectory: './src/routes' }), react()],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'react-vendor': ['react', 'react-dom'],
+            router: ['@tanstack/react-router'],
+            lottie: ['lottie-react'],
+            video: ['react-player'],
+          },
+        },
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
- Add manual chunks config to vite.config.ts for vendor splitting
- Vendor libraries split into separate cacheable chunks: `react-vendor`, `router`, `lottie`, `video`

## Impact
- Better browser caching for unchanged dependencies
- Users don't need to re-download large vendor libraries on app updates
- Improved load times for returning visitors

Closes #239