### PR TITLE
feat(banner): add community voting call to action

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,16 +4,20 @@ import Footer from '../tsx/layout/Footer'
 import { ErrorBoundary } from '../tsx/components/ErrorBoundary'
 import ScrollProgress from '../tsx/components/ScrollProgress'
 import BackToTop from '../tsx/components/BackToTop'
+import VotingBanner from '../tsx/components/VotingBanner'
 
 export const Route = createRootRoute({
   component: () => (
     <>
       <ScrollProgress />
       <BackToTop />
+      <VotingBanner />
       <Header />
-      <ErrorBoundary>
-        <Outlet />
-      </ErrorBoundary>
+      <div className="pt-[var(--voting-banner-height,0px)]">
+        <ErrorBoundary>
+          <Outlet />
+        </ErrorBoundary>
+      </div>
       <Footer />
     </>
   ),

--- a/src/tsx/components/VotingBanner.tsx
+++ b/src/tsx/components/VotingBanner.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react'
+import { useRouterState } from '@tanstack/react-router'
+import { Trophy, X, ArrowRight } from 'lucide-react'
+import { dismissVotingBanner, isVotingBannerDismissed } from '../helper/storage'
+
+const VOTING_URL = 'https://open-source-wettbewerb.de/voting/green-ecolution/'
+const VOTING_DEADLINE = new Date('2026-09-30T23:59:59+02:00').getTime()
+const isVotingOpen = Date.now() <= VOTING_DEADLINE
+
+function VotingBanner() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const [isDismissed, setIsDismissed] = useState(() => isVotingBannerDismissed())
+  const bannerRef = useRef<HTMLElement>(null)
+
+  const isVisible = !isDismissed && isVotingOpen && pathname === '/'
+
+  // Header and page content are pushed down by this, so the height must stay in sync
+  useEffect(() => {
+    const root = document.documentElement
+    const banner = bannerRef.current
+
+    if (!banner) {
+      root.style.removeProperty('--voting-banner-height')
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      root.style.setProperty('--voting-banner-height', `${banner.offsetHeight}px`)
+    })
+    observer.observe(banner)
+
+    return () => {
+      observer.disconnect()
+      root.style.removeProperty('--voting-banner-height')
+    }
+  }, [isVisible])
+
+  const handleDismiss = () => {
+    dismissVotingBanner()
+    setIsDismissed(true)
+  }
+
+  if (!isVisible) return null
+
+  return (
+    <aside
+      ref={bannerRef}
+      aria-label="Aufruf zum Community Voting"
+      className="fixed inset-x-0 top-0 z-40 bg-green-dark-900 text-white"
+    >
+      <div className="relative mx-auto max-w-screen-lg px-4 md:px-6 xl:max-w-screen-xl">
+        <a
+          href={VOTING_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group flex items-center gap-x-3 py-2.5 pr-8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white sm:justify-center sm:gap-x-4 sm:py-2 md:pr-10"
+        >
+          <Trophy className="w-4 h-4 shrink-0 text-green-light-900" aria-hidden />
+
+          <span className="text-xs leading-snug sm:text-sm">
+            <span className="font-semibold">Community Voting</span>
+            <span className="hidden sm:inline">
+              : Green Ecolution steht beim Open-Source-Wettbewerb zur Abstimmung. Noch bis zum 30.
+              September.
+            </span>
+            <span className="block text-white/85 sm:hidden">
+              Green Ecolution beim Open-Source-Wettbewerb unterstützen, noch bis 30.09.
+            </span>
+          </span>
+
+          <span className="hidden shrink-0 items-center gap-x-2 rounded-xl bg-green-light-900 px-4 py-1.5 text-sm font-semibold text-grey-900 transition-colors ease-in-out duration-300 group-hover:bg-white sm:inline-flex">
+            Jetzt abstimmen
+            <ArrowRight className="w-4 h-4 transition-transform ease-in-out duration-300 group-hover:translate-x-1" />
+          </span>
+
+          <ArrowRight className="ml-auto w-4 h-4 shrink-0 sm:hidden" aria-hidden />
+        </a>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Hinweis zum Community Voting schließen"
+          className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer rounded-lg p-1 text-white/70 transition-colors ease-in-out duration-300 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:right-4"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </aside>
+  )
+}
+
+export default VotingBanner

--- a/src/tsx/helper/storage.ts
+++ b/src/tsx/helper/storage.ts
@@ -5,3 +5,11 @@ export function setInitialLoad() {
 export function isInitialLoad(): boolean {
   return localStorage.getItem('green_ecolution_initial_load') !== 'false'
 }
+
+export function dismissVotingBanner() {
+  localStorage.setItem('green_ecolution_voting_banner_dismissed', 'true')
+}
+
+export function isVotingBannerDismissed(): boolean {
+  return localStorage.getItem('green_ecolution_voting_banner_dismissed') === 'true'
+}

--- a/src/tsx/layout/Header.tsx
+++ b/src/tsx/layout/Header.tsx
@@ -74,7 +74,7 @@ function Header() {
         Zum Hauptinhalt springen
       </a>
       <header
-        className={`fixed inset-x-0 top-0 z-50 transition-all ease-in-out duration-300
+        className={`fixed inset-x-0 top-[var(--voting-banner-height,0px)] z-50 transition-all ease-in-out duration-300
             ${isScrolled ? 'bg-white/95 backdrop-blur-sm shadow-lg shadow-grey-900/5' : 'bg-transparent'}`}
       >
         <div className="relative px-4 py-5 max-w-screen-lg mx-auto flex justify-between items-center md:px-6 xl:max-w-screen-xl">


### PR DESCRIPTION
Add a dismissible sticky banner on the homepage that links to the open-source-wettbewerb.de voting page. It hides itself after the voting deadline on 2026-09-30 and remembers a manual dismissal in localStorage.

The banner publishes its height as `--voting-banner-height` so the fixed header and the page content shift down accordingly.