### PR TITLE
fix(hero): keep homepage hero within the visible viewport on mobile

### DIFF
--- a/src/tsx/components/homepage/HomepageHero.tsx
+++ b/src/tsx/components/homepage/HomepageHero.tsx
@@ -87,7 +87,7 @@ function HomepageHero() {
 
   return (
     <section>
-      <div className="overflow-hidden relative mx-auto w-screen h-screen max-w-screen-3xl pointer-events-none before:bg-background-yellow-dot before:bg-cover before:w-4/5 before:h-[100vh] before:max-h-[45rem] before:absolute before:-right-4 before:bottom-0 before:-z-50 before:bg-no-repeat sm:before:-right-10 md:before:max-h-[70rem] 2xl:before:right-0 2xl:before:bg-contain">
+      <div className="overflow-hidden relative mx-auto w-full min-h-[calc(100svh-var(--voting-banner-height,0px))] max-w-screen-3xl pointer-events-none before:bg-background-yellow-dot before:bg-cover before:w-4/5 before:h-[100vh] before:max-h-[45rem] before:absolute before:-right-4 before:bottom-0 before:-z-50 before:bg-no-repeat sm:before:-right-10 md:before:max-h-[70rem] 2xl:before:right-0 2xl:before:bg-contain">
         {/* Organic gradient blob */}
         <div className="absolute inset-0 overflow-hidden pointer-events-none">
           <div

--- a/src/tsx/components/homepage/HomepageHeroTrees.tsx
+++ b/src/tsx/components/homepage/HomepageHeroTrees.tsx
@@ -50,7 +50,7 @@ function HomepageHeroTrees() {
       >
         <Lottie
           aria-hidden="true"
-          className="relative -z-20 h-[40vh] max-h-[20rem] md:max-h-none md:min-h-96 md:h-[60vh]"
+          className="relative -z-20 h-[36svh] max-h-[18rem] md:max-h-none md:min-h-96 md:h-[60vh]"
           animationData={treeLightGreenAnimation}
           autoplay={!reducedMotion}
         />


### PR DESCRIPTION
The hero used h-screen inside the wrapper that is offset by the voting banner height, so the section was always 100vh + banner tall and never fit on one screen. On mobile browsers vh also refers to the largest viewport, adding the address bar height on top. Long copy on narrow screens was additionally clipped by overflow-hidden.

Use a banner-aware min-height based on svh and w-full instead of w-screen. The front tree is slightly smaller on mobile so it stays fully visible below the copy now that the section is shorter.